### PR TITLE
effort isn't used, so report should keep the effort = 1

### DIFF
--- a/bench/Thyme.scala
+++ b/bench/Thyme.scala
@@ -515,7 +515,7 @@ class Thyme(val accuracyTarget: Double = 0.03, watchLoads: Boolean = true, watch
     }
     if (br.runtimeResults.n > 0) { br.runtimeResults = Distribution.compute(br.runtimeResults.data.value, intrinsicError = br.intrinsicError) }
     val t1 = System.nanoTime
-    br.effort = max(1, effort)
+    br.effort = 1
     br.wallClockTime = 1e-9*(t1-t0)
     a
   }


### PR DESCRIPTION
The `effort` argument to bench & friends is completely ignored during the actual timing, but it is used when printing out a `Benched` instance.  This is really misleading -- cranking up `effort` keeps bringing down the runtimes.  Eg. this:

```
    th.pbench(1 + 2, effort = 1)
    th.pbench(2 + 1, effort=1000)
```

leads to:

```
Benchmark (1342177260 calls in 2.559 s)
  Time:    1.892 ns   95% CI 1.827 ns - 1.957 ns   (n=20)
Benchmark (1342177260 calls in 2.645 s)
  Time:    0.001961 ns   95% CI 0.001898 ns - 0.002024 ns   (n=20)
```

This PR isn't really doing the right thing, which would be to use `effort` correctly.  I'm not sure how you mean for it to be used, so instead I am just always setting it to 1 in `Benched`.
